### PR TITLE
StopWatchy - Require Logger

### DIFF
--- a/languages/javascript/stopwatchy-browser/package.json
+++ b/languages/javascript/stopwatchy-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stopwatchy-browser",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A small stopwatch library designed for the browser",
   "main": "dist/bundle.js",
   "scripts": {

--- a/languages/javascript/stopwatchy-browser/src/implementations/BrowserStopWatchFactoryImpl.ts
+++ b/languages/javascript/stopwatchy-browser/src/implementations/BrowserStopWatchFactoryImpl.ts
@@ -8,8 +8,10 @@ import { StopWatchImpl } from "../../../stopwatchy/src/implementations/StopWatch
 import { StopWatchLogger } from "../../../stopwatchy/src/interfaces/StopWatchLogger";
 import { StopWatchLoggerFactory } from "../../../stopwatchy/src/interfaces/StopWatchLoggerFactory";
 import { StopWatchLoggerFactoryImpl } from "../../../stopwatchy/src/implementations/StopWatchLoggerFactoryImpl";
+import { StructuredLogger } from "../../../structured-logger/src/interfaces/StructuredLogger";
 
 export class BrowserStopWatchFactoryImpl implements StopWatchFactory {
+  constructor(private structuredLogger: StructuredLogger) {}
   public createStopWatch(): StopWatch {
     const performanceAPIWrapper: PerformanceAPIWrapper =
       new BrowserPerformanceAPIWrapperImpl();
@@ -18,7 +20,9 @@ export class BrowserStopWatchFactoryImpl implements StopWatchFactory {
     );
     const stopWatchLoggerFactory: StopWatchLoggerFactory =
       new StopWatchLoggerFactoryImpl();
-    const logger: StopWatchLogger = stopWatchLoggerFactory.createLogger();
+    const logger: StopWatchLogger = stopWatchLoggerFactory.createLogger(
+      this.structuredLogger
+    );
     return new StopWatchImpl(timeStampRetriever, logger);
   }
 }

--- a/languages/javascript/stopwatchy-browser/src/index.ts
+++ b/languages/javascript/stopwatchy-browser/src/index.ts
@@ -1,6 +1,9 @@
 import { StopWatchFactory } from "../../stopwatchy/src/interfaces/StopWatchFactory";
 import { BrowserStopWatchFactoryImpl } from "./implementations/BrowserStopWatchFactoryImpl";
+import { StructuredLogger } from "../../structured-logger/src/interfaces/StructuredLogger";
 
-export function getStopWatchFactory(): StopWatchFactory {
-  return new BrowserStopWatchFactoryImpl();
+export function getStopWatchFactory(
+  structuredLogger: StructuredLogger
+): StopWatchFactory {
+  return new BrowserStopWatchFactoryImpl(structuredLogger);
 }

--- a/languages/javascript/stopwatchy-node/package.json
+++ b/languages/javascript/stopwatchy-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stopwatchy-node",
-  "version": "2.3.0",
+  "version": "4.0.0",
   "description": "A small stopwatch library designed for node",
   "main": "dist/bundle.js",
   "scripts": {

--- a/languages/javascript/stopwatchy-node/src/implementations/NodeStopWatchFactoryImpl.ts
+++ b/languages/javascript/stopwatchy-node/src/implementations/NodeStopWatchFactoryImpl.ts
@@ -8,8 +8,10 @@ import { StopWatchImpl } from "../../../stopwatchy/src/implementations/StopWatch
 import { StopWatchLogger } from "../../../stopwatchy/src/interfaces/StopWatchLogger";
 import { StopWatchLoggerFactory } from "../../../stopwatchy/src/interfaces/StopWatchLoggerFactory";
 import { StopWatchLoggerFactoryImpl } from "../../../stopwatchy/src/implementations/StopWatchLoggerFactoryImpl";
+import { StructuredLogger } from "../../../structured-logger/src/interfaces/StructuredLogger";
 
 export class NodeStopWatchFactoryImpl implements StopWatchFactory {
+  constructor(private structuredLogger: StructuredLogger) {}
   public createStopWatch(): StopWatch {
     const performanceAPIWrapper: PerformanceAPIWrapper =
       new NodePerformanceAPIWrapperImpl();
@@ -18,7 +20,9 @@ export class NodeStopWatchFactoryImpl implements StopWatchFactory {
     );
     const stopWatchLoggerFactory: StopWatchLoggerFactory =
       new StopWatchLoggerFactoryImpl();
-    const logger: StopWatchLogger = stopWatchLoggerFactory.createLogger();
+    const logger: StopWatchLogger = stopWatchLoggerFactory.createLogger(
+      this.structuredLogger
+    );
     return new StopWatchImpl(timeStampRetriever, logger);
   }
 }

--- a/languages/javascript/stopwatchy-node/src/index.ts
+++ b/languages/javascript/stopwatchy-node/src/index.ts
@@ -1,6 +1,9 @@
 import { StopWatchFactory } from "../../stopwatchy/src/interfaces/StopWatchFactory";
 import { NodeStopWatchFactoryImpl } from "./implementations/NodeStopWatchFactoryImpl";
+import { StructuredLogger } from "../../structured-logger/src/interfaces/StructuredLogger";
 
-export function getStopWatchFactory(): StopWatchFactory {
-  return new NodeStopWatchFactoryImpl();
+export function getStopWatchFactory(
+  logger: StructuredLogger
+): StopWatchFactory {
+  return new NodeStopWatchFactoryImpl(logger);
 }

--- a/languages/javascript/stopwatchy-node/test/StopWatchFactory.test.ts
+++ b/languages/javascript/stopwatchy-node/test/StopWatchFactory.test.ts
@@ -2,9 +2,12 @@ import { StopWatchFactory } from "../../stopwatchy/src/interfaces/StopWatchFacto
 import { NodeStopWatchFactoryImpl } from "../src/implementations/NodeStopWatchFactoryImpl";
 import { StopWatch } from "../../stopwatchy/src/interfaces/StopWatch";
 import { StopWatchImpl } from "../../stopwatchy/src//implementations/StopWatchImpl";
+import { StructuredLoggerStub } from "../../structured-logger/src/stubs/StructuredLoggerStub";
 
 test("should produce an instance of StopWatchImpl", () => {
-  const stopWatchFactory: StopWatchFactory = new NodeStopWatchFactoryImpl();
+  const stopWatchFactory: StopWatchFactory = new NodeStopWatchFactoryImpl(
+    new StructuredLoggerStub()
+  );
   const stopWatch: StopWatch = stopWatchFactory.createStopWatch();
   expect(stopWatch instanceof StopWatchImpl).toBe(true);
 });

--- a/languages/javascript/stopwatchy-node/test/getStopWatchFactory.test.ts
+++ b/languages/javascript/stopwatchy-node/test/getStopWatchFactory.test.ts
@@ -1,6 +1,11 @@
 import { getStopWatchFactory } from "../src/index";
 import { NodeStopWatchFactoryImpl } from "../src/implementations/NodeStopWatchFactoryImpl";
+import { StructuredLoggerStub } from "../../structured-logger/src/stubs/StructuredLoggerStub";
 
 test("should produce an instance of StopWatchFactoryImpl", () => {
-  expect(getStopWatchFactory() instanceof NodeStopWatchFactoryImpl).toBe(true);
+  const structuredLoggerStub: StructuredLoggerStub = new StructuredLoggerStub();
+  expect(
+    getStopWatchFactory(structuredLoggerStub) instanceof
+      NodeStopWatchFactoryImpl
+  ).toBe(true);
 });

--- a/languages/javascript/stopwatchy/src/implementations/StopWatchLoggerFactoryImpl.ts
+++ b/languages/javascript/stopwatchy/src/implementations/StopWatchLoggerFactoryImpl.ts
@@ -1,12 +1,10 @@
 import { StopWatchLoggerFactory } from "../interfaces/StopWatchLoggerFactory";
 import { StopWatchLogger } from "../interfaces/StopWatchLogger";
 import { StopWatchLoggerImpl } from "./StopWatchLoggerImpl";
-import { StructuredLoggerFactory } from "../../../structured-logger/src/interfaces/StructuredLoggerFactory";
-import { getStructuredLoggerFactory } from "../../../structured-logger/src/index";
+import { StructuredLogger } from "../../../structured-logger/src/interfaces/StructuredLogger";
 
 export class StopWatchLoggerFactoryImpl implements StopWatchLoggerFactory {
-    public createLogger(): StopWatchLogger {
-        const structuredLoggerFactory: StructuredLoggerFactory = getStructuredLoggerFactory();
-        return new StopWatchLoggerImpl(structuredLoggerFactory.createLogger());
+    public createLogger(structuredLogger: StructuredLogger): StopWatchLogger {
+        return new StopWatchLoggerImpl(structuredLogger);
     }
 }

--- a/languages/javascript/stopwatchy/src/interfaces/StopWatchFactory.ts
+++ b/languages/javascript/stopwatchy/src/interfaces/StopWatchFactory.ts
@@ -1,4 +1,5 @@
 import { StopWatch } from "./StopWatch";
+import { StructuredLogger } from "../../../structured-logger/src/interfaces/StructuredLogger";
 
 export interface StopWatchFactory {
   createStopWatch(): StopWatch;

--- a/languages/javascript/stopwatchy/src/interfaces/StopWatchLoggerFactory.ts
+++ b/languages/javascript/stopwatchy/src/interfaces/StopWatchLoggerFactory.ts
@@ -1,5 +1,6 @@
 import { StopWatchLogger } from "./StopWatchLogger";
+import { StructuredLogger } from "../../../structured-logger/src/interfaces/StructuredLogger";
 
 export interface StopWatchLoggerFactory {
-    createLogger(): StopWatchLogger;
+    createLogger(structuredLogger: StructuredLogger): StopWatchLogger;
 }

--- a/languages/javascript/structured-logger/src/stubs/StructuredLoggerStub.ts
+++ b/languages/javascript/structured-logger/src/stubs/StructuredLoggerStub.ts
@@ -1,0 +1,11 @@
+import { StructuredLogger } from "../interfaces/StructuredLogger";
+
+export class StructuredLoggerStub implements StructuredLogger {
+public logError(_logMessage: string): void {}
+  public logWarning(logMessage: string): void {}
+  public logInfo(logMessage: string): void {}
+  public logVerbose(logMessage: string): void {}
+  public logDebug(logMessage: string): void {}
+  public logSilly(logMessage: string): void {}
+  public logCustom(logLevel: number, logMessage: string): void {}
+}


### PR DESCRIPTION
I have made a decision to require loggers in all packages to make it easy to diagnose issues. So, I am adding a logger instance as a required parameter in the factory retriever function for stopwatchy. 