### PR TITLE
Make monotonic clock the default for stopwatch

### DIFF
--- a/languages/ruby/stopwatchy/lib/stopwatchy.rb
+++ b/languages/ruby/stopwatchy/lib/stopwatchy.rb
@@ -11,7 +11,7 @@ module Stopwatchy
   end
   class StopWatch
     
-    def initialize(monotonically_increasing_clock = false)
+    def initialize(monotonically_increasing_clock = true)
       @start_time_stamp = nil
       @stop_time_stamp = nil
       @monotonically_increasing_clock = monotonically_increasing_clock


### PR DESCRIPTION
We currently user the non-monotonic clock as the default for the `stopwatchy` gem. Fixing that by making the `monotonic` clock the default unless and until the user overrides. 