### PR TITLE
Use Date API As Fallback For StopWatch

### DIFF
--- a/languages/javascript/specs/StopWatchy.md
+++ b/languages/javascript/specs/StopWatchy.md
@@ -1,0 +1,59 @@
+# StopWatchy Spec
+
+This document specifies the `StopWatchy` library. The spec is designed to be detail rich to help with the implementation. Please feel free to skim through. 
+
+## Definitions
+
+1. Invalid Elapsed Time - Invalid elapsed time will be equal to -1. If this value is encountered, you can assume that the stopwatch library encountered an error and the value cannot be used.
+2. Monotonically Increasing Clock - A clock that is not related to the wall clock and is not affected by things like NTP and changes to system time. It is a linearly increasing clock that can never go back. 
+
+## Purpose of the library
+
+The main purpose of the library is to expose an interface through which users can measure how long something took to complete. The resolution of the time returned should at least be in milliseconds. This library is designed to be incorporated into your code through the use of a module bundler like `webpack` and is designed to support a wide range of browsers and non-browser JavaScript environments like Node.js. The library expects the presence of at least one of the following APIs in the JavaScript environment
+
+1. Performance API
+2. Date API
+
+If neither one is present, it will return an invalid time measurement.
+
+## Inteface of the library
+
+### StopWatch Interface
+
+`StopWatch`interface that has three functions - `start`, `stop` and `getElapsedTime`.
+
+1. `start` starts the StopWatch and starts recording the time.
+2. `stop` stops an already started StopWatch.
+3. `getElapsedTime` returns the amount of time recorded by the stopped StopWatch. If the stopwatch was never started before calling this function, it will return an invalid elapsed time. If the stopwatch was never stopped before calling this function, it will return an invalid elapsed time.
+
+### StopWatchFactory Interface
+
+`StopWatchFactory` interface is responsible for creating one or more instances of objects that have the `StopWatch` interface. The `StopWatchFactory` interface has only method `createStopWatch`. When called, it returns an instance of an object with the `StopWatch` interface.
+
+### Retrieving StopWatchFactory Interface
+
+You can retrieve an instance of the `StopWatchFactory` interface by calling the `getStopWatchFactory` function. The `getStopWatchFactory` requires a logger instance and you can look into the logger output to see if the library encountered any errors. 
+
+## Example Usage
+
+Assume you have the following code to time
+
+```ts
+function doSomething() {
+    // Some task that takes a long time
+}
+```
+
+To find out how long this function took to excute, you would something as follows
+
+```ts
+import { getStopWatchFactory, StopWatchFactory, StopWatch } from "stopwatchy";
+
+const stopWatchFactory: StopWatchFactory = getStopWatchFactory(logger);
+const stopWatch: StopWatch = stopWatchFactory.createStopWatch();
+stopWatch.start();
+doSomething();
+stopWatch.stop();
+const elapsedTime: number = stopWatch.getElapsedTime();
+console.log(elapsedTime);
+```

--- a/languages/javascript/stopwatchy-browser/package.json
+++ b/languages/javascript/stopwatchy-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stopwatchy-browser",
-  "version": "3.0.0",
+  "version": "5.0.0",
   "description": "A small stopwatch library designed for the browser",
   "main": "dist/bundle.js",
   "scripts": {

--- a/languages/javascript/stopwatchy-browser/src/implementations/BrowserStopWatchFactoryImpl.ts
+++ b/languages/javascript/stopwatchy-browser/src/implementations/BrowserStopWatchFactoryImpl.ts
@@ -3,6 +3,8 @@ import { StopWatch } from "../../../stopwatchy/src/interfaces/StopWatch";
 import { TimeStampRetriever } from "../../../stopwatchy/src/interfaces/TimeStampRetriever";
 import { TimeStampRetrieverImpl } from "../../../stopwatchy/src/implementations/TimeStampRetrieverImpl";
 import { PerformanceAPIWrapper } from "../../../stopwatchy/src/interfaces/PerformanceAPIWrapper";
+import { DateAPIWrapper } from "../../../stopwatchy/src/interfaces/DateAPIWrapper";
+import { DateAPIWrapperImpl } from "../../../stopwatchy/src/implementations/DateAPIWrapperImpl";
 import { BrowserPerformanceAPIWrapperImpl } from "./BrowserPerformanceAPIWrapperImpl";
 import { StopWatchImpl } from "../../../stopwatchy/src/implementations/StopWatchImpl";
 import { StopWatchLogger } from "../../../stopwatchy/src/interfaces/StopWatchLogger";
@@ -15,8 +17,10 @@ export class BrowserStopWatchFactoryImpl implements StopWatchFactory {
   public createStopWatch(): StopWatch {
     const performanceAPIWrapper: PerformanceAPIWrapper =
       new BrowserPerformanceAPIWrapperImpl();
+    const dateAPIWrapper: DateAPIWrapper = new DateAPIWrapperImpl();
     const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
-      performanceAPIWrapper
+      performanceAPIWrapper,
+      dateAPIWrapper
     );
     const stopWatchLoggerFactory: StopWatchLoggerFactory =
       new StopWatchLoggerFactoryImpl();

--- a/languages/javascript/stopwatchy-node/package.json
+++ b/languages/javascript/stopwatchy-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stopwatchy-node",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A small stopwatch library designed for node",
   "main": "dist/bundle.js",
   "scripts": {

--- a/languages/javascript/stopwatchy-node/src/implementations/NodeStopWatchFactoryImpl.ts
+++ b/languages/javascript/stopwatchy-node/src/implementations/NodeStopWatchFactoryImpl.ts
@@ -3,6 +3,8 @@ import { StopWatch } from "../../../stopwatchy/src/interfaces/StopWatch";
 import { TimeStampRetriever } from "../../../stopwatchy/src/interfaces/TimeStampRetriever";
 import { TimeStampRetrieverImpl } from "../../../stopwatchy/src/implementations/TimeStampRetrieverImpl";
 import { PerformanceAPIWrapper } from "../../../stopwatchy/src/interfaces/PerformanceAPIWrapper";
+import { DateAPIWrapper } from "../../../stopwatchy/src/interfaces/DateAPIWrapper";
+import { DateAPIWrapperImpl } from "../../../stopwatchy/src/implementations/DateAPIWrapperImpl";
 import { NodePerformanceAPIWrapperImpl } from "./NodePerformanceAPIWrapperImpl";
 import { StopWatchImpl } from "../../../stopwatchy/src/implementations/StopWatchImpl";
 import { StopWatchLogger } from "../../../stopwatchy/src/interfaces/StopWatchLogger";
@@ -15,8 +17,10 @@ export class NodeStopWatchFactoryImpl implements StopWatchFactory {
   public createStopWatch(): StopWatch {
     const performanceAPIWrapper: PerformanceAPIWrapper =
       new NodePerformanceAPIWrapperImpl();
+    const dateAPIWrapper: DateAPIWrapper = new DateAPIWrapperImpl();
     const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
-      performanceAPIWrapper
+      performanceAPIWrapper,
+      dateAPIWrapper
     );
     const stopWatchLoggerFactory: StopWatchLoggerFactory =
       new StopWatchLoggerFactoryImpl();

--- a/languages/javascript/stopwatchy-node/test/StopWatch.test.ts
+++ b/languages/javascript/stopwatchy-node/test/StopWatch.test.ts
@@ -15,9 +15,7 @@ test("should return invalid elapsed time if start was never called", () => {
     stopWatchLogger
   );
   stopWatch.stop();
-  expect(stopWatch.getElapsedTimeInMilliSeconds()).toBe(
-    INVALID_STOP_WATCH_ELAPSED_TIME
-  );
+  expect(stopWatch.getElapsedTime()).toBe(INVALID_STOP_WATCH_ELAPSED_TIME);
 });
 
 test("should return invalid elapsed time if stop was never called", () => {
@@ -29,9 +27,7 @@ test("should return invalid elapsed time if stop was never called", () => {
     stopWatchLogger
   );
   stopWatch.start();
-  expect(stopWatch.getElapsedTimeInMilliSeconds()).toBe(
-    INVALID_STOP_WATCH_ELAPSED_TIME
-  );
+  expect(stopWatch.getElapsedTime()).toBe(INVALID_STOP_WATCH_ELAPSED_TIME);
 });
 
 test("should return a valid elapsed time if both start and stop were called", () => {
@@ -44,7 +40,5 @@ test("should return a valid elapsed time if both start and stop were called", ()
   );
   stopWatch.start();
   stopWatch.stop();
-  expect(stopWatch.getElapsedTimeInMilliSeconds()).not.toBe(
-    INVALID_STOP_WATCH_ELAPSED_TIME
-  );
+  expect(stopWatch.getElapsedTime()).not.toBe(INVALID_STOP_WATCH_ELAPSED_TIME);
 });

--- a/languages/javascript/stopwatchy-node/test/TimeStampRetriever.test.ts
+++ b/languages/javascript/stopwatchy-node/test/TimeStampRetriever.test.ts
@@ -1,37 +1,69 @@
 import { TimeStampRetriever } from "../../stopwatchy/src/interfaces/TimeStampRetriever";
 import { TimeStampRetrieverImpl } from "../../stopwatchy/src/implementations/TimeStampRetrieverImpl";
-import { PerformanceAPIWrapper } from "../../stopwatchy/src/interfaces/PerformanceAPIWrapper";
+import { DateAPIWrapper } from "../../stopwatchy/src/interfaces/DateAPIWrapper";
 import { MockPerformanceAPIWrapper } from "./mocks/MockPerformanceAPIWrapper";
-import { PerformanceAPIWrapperStub } from "./stubs/PerformanceAPIWrapperStub";
+import { MockDateAPIWrapper } from "./mocks/MockDateAPIWrapper";
+import { DateAPIWrapperStub } from "./stubs/DateAPIWrapperStub";
 import { INVALID_TIME_STAMP } from "../../stopwatchy/src/constants";
 
-test("If performance is not defined, then the time stamp retriever should return invalid timestamp", () => {
+test("If performance is not defined, then the time stamp retriever should return the timestamp from the Date API", () => {
   const mockPerformanceAPIWrapper: MockPerformanceAPIWrapper =
     new MockPerformanceAPIWrapper();
   mockPerformanceAPIWrapper.failPerformanceDefinedCheck();
+  const timeValueToReturnBack = 10;
+  const mockDateAPIWrapper: MockDateAPIWrapper = new MockDateAPIWrapper();
+  mockDateAPIWrapper.setGetTimeValueToReturnBack(timeValueToReturnBack);
   const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
-    mockPerformanceAPIWrapper
+    mockPerformanceAPIWrapper,
+    mockDateAPIWrapper
   );
-  expect(timeStampRetriever.getCurrentTimeStamp()).toEqual(INVALID_TIME_STAMP);
+  expect(timeStampRetriever.getCurrentTimeStamp()).toEqual(
+    timeValueToReturnBack
+  );
 });
 
-test("If performance.now is not defined, then the time stamp retriever should return invalid timestamp", () => {
+test("If performance.now is not defined, then the time stamp retriever should return the timestamp from the Date API", () => {
   const mockPerformanceAPIWrapper: MockPerformanceAPIWrapper =
     new MockPerformanceAPIWrapper();
   mockPerformanceAPIWrapper.failPerformanceNowDefinedCheck();
+  const timeValueToReturnBack = 10;
+  const mockDateAPIWrapper: MockDateAPIWrapper = new MockDateAPIWrapper();
+  mockDateAPIWrapper.setGetTimeValueToReturnBack(timeValueToReturnBack);
   const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
-    mockPerformanceAPIWrapper
+    mockPerformanceAPIWrapper,
+    mockDateAPIWrapper
   );
-  expect(timeStampRetriever.getCurrentTimeStamp()).toEqual(INVALID_TIME_STAMP);
+  expect(timeStampRetriever.getCurrentTimeStamp()).toEqual(
+    timeValueToReturnBack
+  );
 });
 
-test("If both performance and performance.now is defined, then ", () => {
-  const performanceAPIWrapper: PerformanceAPIWrapper =
-    new PerformanceAPIWrapperStub();
+test("If both performance and performance.now is defined, then the timestamp should be returned from the performance API", () => {
+  const performanceNowValueToReturnBack = 10;
+  const mockPerformanceAPIWrapper: MockPerformanceAPIWrapper =
+    new MockPerformanceAPIWrapper();
+  mockPerformanceAPIWrapper.setPerformanceNowValueToReturnBack(
+    performanceNowValueToReturnBack
+  );
+  const dateAPIWrapper: DateAPIWrapper = new DateAPIWrapperStub();
   const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
-    performanceAPIWrapper
+    mockPerformanceAPIWrapper,
+    dateAPIWrapper
   );
-  expect(timeStampRetriever.getCurrentTimeStamp()).not.toEqual(
-    INVALID_TIME_STAMP
+  expect(timeStampRetriever.getCurrentTimeStamp()).toEqual(
+    performanceNowValueToReturnBack
   );
+});
+
+test("If both performance API and date API are not supported, then it should return an invalid timestamp", () => {
+  const mockPerformanceAPIWrapper: MockPerformanceAPIWrapper =
+    new MockPerformanceAPIWrapper();
+  mockPerformanceAPIWrapper.failPerformanceDefinedCheck();
+  const mockDateAPIWrapper: MockDateAPIWrapper = new MockDateAPIWrapper();
+  mockDateAPIWrapper.failDateAPISupportedCheck();
+  const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
+    mockPerformanceAPIWrapper,
+    mockDateAPIWrapper
+  );
+  expect(timeStampRetriever.getCurrentTimeStamp()).toEqual(INVALID_TIME_STAMP);
 });

--- a/languages/javascript/stopwatchy-node/test/mocks/MockDateAPIWrapper.ts
+++ b/languages/javascript/stopwatchy-node/test/mocks/MockDateAPIWrapper.ts
@@ -1,0 +1,23 @@
+import { DateAPIWrapper } from "../../../stopwatchy/src/interfaces/DateAPIWrapper";
+import { INVALID_TIME_STAMP } from "../../../stopwatchy/src/constants";
+
+export class MockDateAPIWrapper implements DateAPIWrapper {
+  private shouldFailDateAPISupportedCheck: boolean;
+  private timeValueToReturnBack: number;
+  constructor() {
+    this.shouldFailDateAPISupportedCheck = false;
+    this.timeValueToReturnBack = INVALID_TIME_STAMP;
+  }
+  public isDateAPISupported(): boolean {
+    return !this.shouldFailDateAPISupportedCheck;
+  }
+  public getTime(): number {
+    return this.timeValueToReturnBack;
+  }
+  public failDateAPISupportedCheck(): void {
+    this.shouldFailDateAPISupportedCheck = true;
+  }
+  public setGetTimeValueToReturnBack(timeValue: number): void {
+    this.timeValueToReturnBack = timeValue;
+  }
+}

--- a/languages/javascript/stopwatchy-node/test/mocks/MockPerformanceAPIWrapper.ts
+++ b/languages/javascript/stopwatchy-node/test/mocks/MockPerformanceAPIWrapper.ts
@@ -4,9 +4,11 @@ import { INVALID_PERFORMANCE_NOW_VALUE } from "../../../stopwatchy/src/constants
 export class MockPerformanceAPIWrapper implements PerformanceAPIWrapper {
   private performanceDefinedCheckShouldPass: boolean;
   private performanceNowDefinedCheckShouldPass: boolean;
+  private performanceNowValueToReturnBack: number;
   constructor() {
     this.performanceDefinedCheckShouldPass = true;
     this.performanceNowDefinedCheckShouldPass = true;
+    this.performanceNowValueToReturnBack = INVALID_PERFORMANCE_NOW_VALUE;
   }
   public isPerformanceDefined(): boolean {
     return this.performanceDefinedCheckShouldPass;
@@ -15,12 +17,15 @@ export class MockPerformanceAPIWrapper implements PerformanceAPIWrapper {
     return this.performanceNowDefinedCheckShouldPass;
   }
   public getPerformanceNow(): number {
-    return INVALID_PERFORMANCE_NOW_VALUE;
+    return this.performanceNowValueToReturnBack;
   }
   public failPerformanceDefinedCheck(): void {
     this.performanceDefinedCheckShouldPass = false;
   }
   public failPerformanceNowDefinedCheck(): void {
     this.performanceNowDefinedCheckShouldPass = false;
+  }
+  public setPerformanceNowValueToReturnBack(valueToReturnBack: number): void {
+    this.performanceNowValueToReturnBack = valueToReturnBack;
   }
 }

--- a/languages/javascript/stopwatchy-node/test/stubs/DateAPIWrapperStub.ts
+++ b/languages/javascript/stopwatchy-node/test/stubs/DateAPIWrapperStub.ts
@@ -1,0 +1,11 @@
+import { DateAPIWrapper } from "../../../stopwatchy/src/interfaces/DateAPIWrapper";
+import { INVALID_TIME_STAMP } from "../../../stopwatchy/src/constants";
+
+export class DateAPIWrapperStub implements DateAPIWrapper {
+  public isDateAPISupported(): boolean {
+    return true;
+  }
+  public getTime(): number {
+    return INVALID_TIME_STAMP;
+  }
+}

--- a/languages/javascript/stopwatchy/src/constants.ts
+++ b/languages/javascript/stopwatchy/src/constants.ts
@@ -1,3 +1,4 @@
 export const INVALID_PERFORMANCE_NOW_VALUE = -1;
 export const INVALID_TIME_STAMP = -1;
 export const INVALID_STOP_WATCH_ELAPSED_TIME = -1;
+export const INVALID_DATE_VALUE = -1;

--- a/languages/javascript/stopwatchy/src/implementations/DateAPIWrapperImpl.ts
+++ b/languages/javascript/stopwatchy/src/implementations/DateAPIWrapperImpl.ts
@@ -1,0 +1,15 @@
+import { DateAPIWrapper } from "../interfaces/DateAPIWrapper";
+import { INVALID_DATE_VALUE } from "../constants";
+
+export class DateAPIWrapperImpl implements DateAPIWrapper {
+    public getTime(): number {
+        if (!this.isDateAPISupported()) {
+            return INVALID_DATE_VALUE;
+        }
+        const currentDate: Date = new Date();
+        return currentDate.getTime();
+    }
+    public isDateAPISupported(): boolean {
+        return Date != null;
+    }
+}

--- a/languages/javascript/stopwatchy/src/implementations/StopWatchImpl.ts
+++ b/languages/javascript/stopwatchy/src/implementations/StopWatchImpl.ts
@@ -23,7 +23,7 @@ export class StopWatchImpl implements StopWatch {
     }
     this.stopTimeStamp = this.timeStampRetriever.getCurrentTimeStamp();
   }
-  public getElapsedTimeInMilliSeconds(): number {
+  public getElapsedTime(): number {
     if (this.startTimeStamp === undefined) {
       this.logger.getElapsedTimeCalledBeforeStart();
       return INVALID_STOP_WATCH_ELAPSED_TIME;

--- a/languages/javascript/stopwatchy/src/implementations/TimeStampRetrieverImpl.ts
+++ b/languages/javascript/stopwatchy/src/implementations/TimeStampRetrieverImpl.ts
@@ -1,17 +1,20 @@
 import { TimeStampRetriever } from "../interfaces/TimeStampRetriever";
 import { PerformanceAPIWrapper } from "../interfaces/PerformanceAPIWrapper";
+import { DateAPIWrapper } from "../interfaces/DateAPIWrapper";
 import { INVALID_TIME_STAMP } from "../constants";
 
 export class TimeStampRetrieverImpl implements TimeStampRetriever {
   private isPerformanceAPIAvailable: boolean;
-  constructor(private performanceAPIWrapper: PerformanceAPIWrapper) {
+  private isDateAPIAvailable: boolean;
+  constructor(private performanceAPIWrapper: PerformanceAPIWrapper, private dateAPIWrapper: DateAPIWrapper) {
     this.isPerformanceAPIAvailable =
-      performanceAPIWrapper.isPerformanceDefined() &&
-      performanceAPIWrapper.isPerformanceNowDefined();
+      this.performanceAPIWrapper.isPerformanceDefined() &&
+      this.performanceAPIWrapper.isPerformanceNowDefined();
+    this.isDateAPIAvailable = this.dateAPIWrapper.isDateAPISupported();
   }
   public getCurrentTimeStamp(): number {
     return this.isPerformanceAPIAvailable
       ? this.performanceAPIWrapper.getPerformanceNow()
-      : INVALID_TIME_STAMP;
+      : this.isDateAPIAvailable ? this.dateAPIWrapper.getTime() : INVALID_TIME_STAMP;
   }
 }

--- a/languages/javascript/stopwatchy/src/interfaces/DateAPIWrapper.ts
+++ b/languages/javascript/stopwatchy/src/interfaces/DateAPIWrapper.ts
@@ -1,0 +1,4 @@
+export interface DateAPIWrapper {
+    isDateAPISupported(): boolean;
+    getTime(): number;
+}

--- a/languages/javascript/stopwatchy/src/interfaces/StopWatch.ts
+++ b/languages/javascript/stopwatchy/src/interfaces/StopWatch.ts
@@ -1,5 +1,5 @@
 export interface StopWatch {
   start(): void;
   stop(): void;
-  getElapsedTimeInMilliSeconds(): number;
+  getElapsedTime(): number;
 }


### PR DESCRIPTION
To increase browser compatibility, I have decided to fallback to using date API if performance API is not found. 