### PR TITLE
Use StopWatch To Time Operations

### DIFF
--- a/languages/javascript/operation-abstraction-browser/package.json
+++ b/languages/javascript/operation-abstraction-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operation-abstraction-browser",
-  "version": "1.2.0",
+  "version": "0.4.0",
   "description": "A small operations library",
   "main": "dist/bundle.js",
   "scripts": {

--- a/languages/javascript/operation-abstraction-browser/package.json
+++ b/languages/javascript/operation-abstraction-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operation-abstraction-browser",
-  "version": "0.3.0",
+  "version": "1.2.0",
   "description": "A small operations library",
   "main": "dist/bundle.js",
   "scripts": {

--- a/languages/javascript/operation-abstraction-browser/src/index.ts
+++ b/languages/javascript/operation-abstraction-browser/src/index.ts
@@ -1,9 +1,12 @@
 import { OperationFactory } from "../../operation/src/interfaces/OperationFactory";
 import { OperationFactoryImpl } from "../../operation/src/implementations/OperationFactoryImpl";
 import { StructuredLogger } from "../../structured-logger/src/interfaces/StructuredLogger";
+import { StopWatchFactory } from "../../stopwatchy/src/interfaces/StopWatchFactory";
+import { getStopWatchFactory } from "../../stopwatchy-browser/src/index";
 
 export function getOperationFactory(
   logger: StructuredLogger
 ): OperationFactory {
-  return new OperationFactoryImpl(logger);
+  const stopWatchFactory: StopWatchFactory = getStopWatchFactory(logger);
+  return new OperationFactoryImpl(stopWatchFactory, logger);
 }

--- a/languages/javascript/operation-abstraction-node/package.json
+++ b/languages/javascript/operation-abstraction-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operation-abstraction-node",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A small operations library",
   "main": "dist/bundle.js",
   "scripts": {

--- a/languages/javascript/operation-abstraction-node/package.json
+++ b/languages/javascript/operation-abstraction-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operation-abstraction-node",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A small operations library",
   "main": "dist/bundle.js",
   "scripts": {

--- a/languages/javascript/operation-abstraction-node/src/index.ts
+++ b/languages/javascript/operation-abstraction-node/src/index.ts
@@ -1,9 +1,12 @@
 import { OperationFactory } from "../../operation/src/interfaces/OperationFactory";
 import { OperationFactoryImpl } from "../../operation/src/implementations/OperationFactoryImpl";
 import { StructuredLogger } from "../../structured-logger/src/interfaces/StructuredLogger";
+import { StopWatchFactory } from "../../stopwatchy/src/interfaces/StopWatchFactory";
+import { getStopWatchFactory } from "../../stopwatchy-node/src/index";
 
 export function getOperationFactory(
   logger: StructuredLogger
 ): OperationFactory {
-  return new OperationFactoryImpl(logger);
+  const stopWatchFactory: StopWatchFactory = getStopWatchFactory(logger);
+  return new OperationFactoryImpl(stopWatchFactory, logger);
 }

--- a/languages/javascript/operation/src/implementations/OperationFactoryImpl.ts
+++ b/languages/javascript/operation/src/implementations/OperationFactoryImpl.ts
@@ -2,10 +2,13 @@ import { OperationFactory } from "../interfaces/OperationFactory";
 import { Operation } from "../interfaces/Operation";
 import { OperationImpl } from "./OperationImpl";
 import { StructuredLogger } from "../../../structured-logger/src/interfaces/StructuredLogger";
+import { StopWatchFactory } from "../../../stopwatchy/src/interfaces/StopWatchFactory";
+import { StopWatch } from "../../../stopwatchy/src/interfaces/StopWatch";
 
 export class OperationFactoryImpl implements OperationFactory {
-    constructor(private structuredLogger: StructuredLogger) {}
+    constructor(private stopWatchFactory: StopWatchFactory, private structuredLogger: StructuredLogger) {}
     public createOperation<OperationReturnType>(operationName: string, callbackFunction: () => OperationReturnType): Operation<OperationReturnType> {
-        return new OperationImpl<OperationReturnType>(operationName, callbackFunction, this.structuredLogger);
+        const stopWatch: StopWatch = this.stopWatchFactory.createStopWatch();
+        return new OperationImpl<OperationReturnType>(operationName, callbackFunction, stopWatch, this.structuredLogger);
     }
 }

--- a/languages/javascript/operation/src/implementations/OperationImpl.ts
+++ b/languages/javascript/operation/src/implementations/OperationImpl.ts
@@ -1,16 +1,28 @@
 import { Operation } from "../interfaces/Operation";
 import { StructuredLogger } from "../../../structured-logger/src/interfaces/StructuredLogger";
+import { StopWatch } from "../../../stopwatchy/src/interfaces/StopWatch";
+import { OperationLog } from "../interfaces/OperationLog";
 
 export class OperationImpl<OperationReturnType> implements Operation<OperationReturnType> {
   constructor(
     private operationName: string,
     private callbackFunction: () => OperationReturnType,
+    private stopWatch: StopWatch,
     private logger: StructuredLogger
   ) {}
   public getOperationName(): string {
     return this.operationName;
   }
   public getResult(): OperationReturnType {
-    return this.callbackFunction();
+    this.stopWatch.start();
+    const resultToReturn: OperationReturnType = this.callbackFunction();
+    this.stopWatch.stop();
+    const elapsedTime: number = this.stopWatch.getElapsedTime();
+    const operationLog: OperationLog = {
+      operationName: this.operationName,
+      elapsedTime: elapsedTime
+    };
+    this.logger.logInfo(JSON.stringify(operationLog));
+    return resultToReturn;
   }
 }

--- a/languages/javascript/operation/src/interfaces/OperationLog.ts
+++ b/languages/javascript/operation/src/interfaces/OperationLog.ts
@@ -1,0 +1,4 @@
+export interface OperationLog {
+    operationName: string,
+    elapsedTime: number;
+}


### PR DESCRIPTION
One of the most important use cases for operations is to figure out how long an operation takes. We have the ability to time operations using the `StopWatchy` package code. So, I am incorporating a stopwatch into operations. 