### PR TITLE
Fixing Operation Package Version

### DIFF
--- a/languages/javascript/operation-abstraction-browser/package.json
+++ b/languages/javascript/operation-abstraction-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operation-abstraction-browser",
-  "version": "0.4.0",
+  "version": "4.0.0",
   "description": "A small operations library",
   "main": "dist/bundle.js",
   "scripts": {

--- a/languages/javascript/operation-abstraction-node/package.json
+++ b/languages/javascript/operation-abstraction-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operation-abstraction-node",
-  "version": "1.3.0",
+  "version": "4.0.0",
   "description": "A small operations library",
   "main": "dist/bundle.js",
   "scripts": {


### PR DESCRIPTION
Yarn publish keeps failing for some reason. This resulted in incorrect package versions. So, I just decided to bump the package version to `4.0.0` to regularize it. I will start using `npm publish` instead of `yarn publish` to fix these failures. 