### PR TITLE
Fix Workflow Typo

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,5 +1,5 @@
 name: GitHub Actions Demo
-on: [pullrequest]
+on: [pull_request]
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I accidentally wrote `pullrequest` instead of `pull_request`. This broke the workflow. Fixing it. 