### PR TITLE
Moving Stubs Into A Separate Folder

### DIFF
--- a/languages/javascript/operation-abstraction-node/test/Operation.test.ts
+++ b/languages/javascript/operation-abstraction-node/test/Operation.test.ts
@@ -1,7 +1,7 @@
 import { getOperationFactory } from "../src/index";
 import { OperationFactory } from "../../operation/src/interfaces/OperationFactory";
 import { Operation } from "../../operation/src/interfaces/Operation";
-import { StructuredLoggerStub } from "../../structured-logger/src/stubs/StructuredLoggerStub";
+import { StructuredLoggerStub } from "../../stubs/StructuredLoggerStub";
 
 test("calling getOperationName should return the name of the operation", () => {
   const operationFactory: OperationFactory = getOperationFactory(

--- a/languages/javascript/operation-abstraction-node/test/OperationFactory.test.ts
+++ b/languages/javascript/operation-abstraction-node/test/OperationFactory.test.ts
@@ -1,7 +1,7 @@
 import { getOperationFactory } from "../src/index";
 import { OperationFactory } from "../../operation/src/interfaces/OperationFactory";
 import { OperationImpl } from "../../operation/src/implementations/OperationImpl";
-import { StructuredLoggerStub } from "../../structured-logger/src/stubs/StructuredLoggerStub";
+import { StructuredLoggerStub } from "../../stubs/StructuredLoggerStub";
 
 test("createOperation should return an instance of an operation", () => {
   const operationFactory: OperationFactory = getOperationFactory(

--- a/languages/javascript/operation-abstraction-node/test/getOperationFactory.test.ts
+++ b/languages/javascript/operation-abstraction-node/test/getOperationFactory.test.ts
@@ -1,6 +1,6 @@
 import { getOperationFactory } from "../src/index";
 import { OperationFactoryImpl } from "../../operation/src/implementations/OperationFactoryImpl";
-import { StructuredLoggerStub } from "../../structured-logger/src/stubs/StructuredLoggerStub";
+import { StructuredLoggerStub } from "../../stubs/StructuredLoggerStub";
 
 test("getOperationFactory should return an instance of OperationFactory", () => {
   expect(

--- a/languages/javascript/stopwatchy-node/test/StopWatchFactory.test.ts
+++ b/languages/javascript/stopwatchy-node/test/StopWatchFactory.test.ts
@@ -2,7 +2,7 @@ import { StopWatchFactory } from "../../stopwatchy/src/interfaces/StopWatchFacto
 import { NodeStopWatchFactoryImpl } from "../src/implementations/NodeStopWatchFactoryImpl";
 import { StopWatch } from "../../stopwatchy/src/interfaces/StopWatch";
 import { StopWatchImpl } from "../../stopwatchy/src//implementations/StopWatchImpl";
-import { StructuredLoggerStub } from "../../structured-logger/src/stubs/StructuredLoggerStub";
+import { StructuredLoggerStub } from "../../stubs/StructuredLoggerStub";
 
 test("should produce an instance of StopWatchImpl", () => {
   const stopWatchFactory: StopWatchFactory = new NodeStopWatchFactoryImpl(

--- a/languages/javascript/stopwatchy-node/test/getStopWatchFactory.test.ts
+++ b/languages/javascript/stopwatchy-node/test/getStopWatchFactory.test.ts
@@ -1,6 +1,6 @@
 import { getStopWatchFactory } from "../src/index";
 import { NodeStopWatchFactoryImpl } from "../src/implementations/NodeStopWatchFactoryImpl";
-import { StructuredLoggerStub } from "../../structured-logger/src/stubs/StructuredLoggerStub";
+import { StructuredLoggerStub } from "../../stubs/StructuredLoggerStub";
 
 test("should produce an instance of StopWatchFactoryImpl", () => {
   const structuredLoggerStub: StructuredLoggerStub = new StructuredLoggerStub();

--- a/languages/javascript/structured-logger/src/implementations/StructuredLoggerFactoryImpl.ts
+++ b/languages/javascript/structured-logger/src/implementations/StructuredLoggerFactoryImpl.ts
@@ -12,7 +12,7 @@ export class StructuredLoggerFactoryImpl implements StructuredLoggerFactory {
     if (observers != null) {
       observers.forEach((observer: LoggerObserver) => {
         logger.subscribe(observer);
-      })
+      });
     }
     return new StructuredLoggerImpl(logger);
   }

--- a/languages/javascript/stubs/StructuredLoggerStub.ts
+++ b/languages/javascript/stubs/StructuredLoggerStub.ts
@@ -1,4 +1,5 @@
-import { StructuredLogger } from "../interfaces/StructuredLogger";
+/* eslint-disable */ 
+import { StructuredLogger } from "../structured-logger/src/interfaces/StructuredLogger";
 
 export class StructuredLoggerStub implements StructuredLogger {
 public logError(_logMessage: string): void {}


### PR DESCRIPTION
Stubs do not belong in the repository where the interfaces are defined. They are supposed to be written by consumers who do not want to use the real implementation. So, I am moving the stubs into a separate folder to easily share across projects. 