### PR TITLE
Add Error Catching Logic Into Operations

### DIFF
--- a/languages/javascript/operation-abstraction-node/test/Operation.test.ts
+++ b/languages/javascript/operation-abstraction-node/test/Operation.test.ts
@@ -13,9 +13,11 @@ test("calling getOperationName should return the name of the operation", () => {
   );
   const operationName = "HelloWorldOperation";
   const callbackFunction: () => void = () => console.log("Hello world!!");
+  const fallbackResult: void = undefined;
   const operation: Operation<void> = operationFactory.createOperation(
     operationName,
-    callbackFunction
+    callbackFunction,
+    fallbackResult
   );
   expect(operation.getOperationName()).toEqual(operationName);
 });
@@ -26,9 +28,11 @@ test("calling getResult should return the output of the callback function", () =
   );
   const operationName = "SumOperation";
   const callbackFunction: () => number = () => 2 + 2;
+  const fallbackResult = 0;
   const operation: Operation<void> = operationFactory.createOperation(
     operationName,
-    callbackFunction
+    callbackFunction,
+    fallbackResult
   );
   expect(operation.getResult()).toEqual(callbackFunction());
 });
@@ -39,9 +43,11 @@ test("calling getResult should return undefined for a void callback function", (
   );
   const operationName = "HelloWorldOperation";
   const callbackFunction: () => void = () => console.log("Hello World");
+  const fallbackResult: void = undefined;
   const operation: Operation<void> = operationFactory.createOperation(
     operationName,
-    callbackFunction
+    callbackFunction,
+    fallbackResult
   );
   expect(operation.getResult()).toEqual(undefined);
 });
@@ -59,10 +65,35 @@ test("calling addProperty from the operation callback should result in the prope
   ) => {
     operation.addProperty("TestKey", "TestValue");
   };
+  const fallbackResult: void = undefined;
   const operation: Operation<void> = operationFactory.createOperation(
     operationName,
-    callbackFunction
+    callbackFunction,
+    fallbackResult
   );
   operation.getResult();
+  expect(logger.getCapturedLogs()).toMatchSnapshot();
+});
+
+test("operation should return the fallback result if an exception was encountered and the exception should be logged out", () => {
+  const logger: StructuredLoggerSpy = new StructuredLoggerSpy();
+  const stopWatchFactory: StopWatchFactory = new StopWatchFactoryStub();
+  const operationFactory: OperationFactory = new OperationFactoryImpl(
+    stopWatchFactory,
+    logger
+  );
+  const operationName = "TestAddPropertyOperation";
+  const callbackFunction: (operation: Operation<number>) => number = (
+    operation: Operation<number>
+  ) => {
+    throw new Error("Throwing an exception");
+  };
+  const fallbackResult = 10;
+  const operation: Operation<number> = operationFactory.createOperation(
+    operationName,
+    callbackFunction,
+    fallbackResult
+  );
+  expect(operation.getResult()).toEqual(fallbackResult);
   expect(logger.getCapturedLogs()).toMatchSnapshot();
 });

--- a/languages/javascript/operation-abstraction-node/test/OperationFactory.test.ts
+++ b/languages/javascript/operation-abstraction-node/test/OperationFactory.test.ts
@@ -9,8 +9,12 @@ test("createOperation should return an instance of an operation", () => {
   );
   const operationName = "TestOperation";
   const callbackFunction: () => void = () => console.log("Hello world!!");
+  const fallbackResult: void = undefined;
   expect(
-    operationFactory.createOperation(operationName, callbackFunction) instanceof
-      OperationImpl
+    operationFactory.createOperation(
+      operationName,
+      callbackFunction,
+      fallbackResult
+    ) instanceof OperationImpl
   ).toBe(true);
 });

--- a/languages/javascript/operation-abstraction-node/test/__snapshots__/Operation.test.ts.snap
+++ b/languages/javascript/operation-abstraction-node/test/__snapshots__/Operation.test.ts.snap
@@ -6,7 +6,21 @@ Object {
   "debugLogs": Array [],
   "errorLogs": Array [],
   "infoLogs": Array [
-    "{\\"operationName\\":\\"TestAddPropertyOperation\\",\\"elapsedTime\\":10,\\"propertyBag\\":{\\"TestKey\\":\\"TestValue\\"}}",
+    "{\\"operationName\\":\\"TestAddPropertyOperation\\",\\"elapsedTime\\":10,\\"didOperationSucceed\\":true,\\"encounteredException\\":false,\\"propertyBag\\":{\\"TestKey\\":\\"TestValue\\"}}",
+  ],
+  "sillyLogs": Array [],
+  "verboseLogs": Array [],
+  "warningLogs": Array [],
+}
+`;
+
+exports[`operation should return the fallback result if an exception was encountered and the exception should be logged out 1`] = `
+Object {
+  "customLogs": Array [],
+  "debugLogs": Array [],
+  "errorLogs": Array [],
+  "infoLogs": Array [
+    "{\\"operationName\\":\\"TestAddPropertyOperation\\",\\"elapsedTime\\":10,\\"didOperationSucceed\\":false,\\"encounteredException\\":true,\\"exceptionInfo\\":{},\\"propertyBag\\":{}}",
   ],
   "sillyLogs": Array [],
   "verboseLogs": Array [],

--- a/languages/javascript/operation/src/implementations/OperationFactoryImpl.ts
+++ b/languages/javascript/operation/src/implementations/OperationFactoryImpl.ts
@@ -7,8 +7,8 @@ import { StopWatch } from "../../../stopwatchy/src/interfaces/StopWatch";
 
 export class OperationFactoryImpl implements OperationFactory {
     constructor(private stopWatchFactory: StopWatchFactory, private structuredLogger: StructuredLogger) {}
-    public createOperation<OperationReturnType>(operationName: string, callbackFunction: (operation: Operation<OperationReturnType>) => OperationReturnType): Operation<OperationReturnType> {
+    public createOperation<OperationReturnType>(operationName: string, callbackFunction: (operation: Operation<OperationReturnType>) => OperationReturnType, fallbackResult: OperationReturnType): Operation<OperationReturnType> {
         const stopWatch: StopWatch = this.stopWatchFactory.createStopWatch();
-        return new OperationImpl<OperationReturnType>(operationName, callbackFunction, stopWatch, this.structuredLogger);
+        return new OperationImpl<OperationReturnType>(operationName, callbackFunction, stopWatch, fallbackResult, this.structuredLogger);
     }
 }

--- a/languages/javascript/operation/src/interfaces/OperationFactory.ts
+++ b/languages/javascript/operation/src/interfaces/OperationFactory.ts
@@ -1,5 +1,5 @@
 import { Operation } from "./Operation";
 
 export interface OperationFactory {
-    createOperation<OperationReturnType>(operationName: string, callbackFunction: (operation: Operation<OperationReturnType>) => OperationReturnType): Operation<OperationReturnType>;
+    createOperation<OperationReturnType>(operationName: string, callbackFunction: (operation: Operation<OperationReturnType>) => OperationReturnType, fallbackResult: OperationReturnType): Operation<OperationReturnType>;
 }

--- a/languages/javascript/operation/src/interfaces/OperationLog.ts
+++ b/languages/javascript/operation/src/interfaces/OperationLog.ts
@@ -1,5 +1,8 @@
 export interface OperationLog {
     operationName: string,
     elapsedTime: number;
+    didOperationSucceed: boolean;
+    encounteredException: boolean;
+    exceptionInfo: any;
     propertyBag: Record<string, unknown>
 }


### PR DESCRIPTION
We do not want errors to propagate further than the operation scope. So, I am adding support for trapping exceptions with in the operation scope. If an exception is encountered, it will return the provided fallback result. 