### PR TITLE
Remove Rake Dependency To Fix Security Issues

### DIFF
--- a/languages/ruby/Loggy/Gemfile
+++ b/languages/ruby/Loggy/Gemfile
@@ -4,7 +4,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in stopwatchy.gemspec
 gemspec
-
-gem "rake", "~> 13.0"
-
-gem "rubocop", "~> 1.7"

--- a/languages/ruby/stopwatchy/Gemfile
+++ b/languages/ruby/stopwatchy/Gemfile
@@ -4,7 +4,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in stopwatchy.gemspec
 gemspec
-
-gem "rake", "~> 13.0"
-
-gem "rubocop", "~> 1.7"


### PR DESCRIPTION
The version of rake used in gems is very old. But I am not using `rake` at this moment. So, I am just removing the rake dependency instead of attempting to bump it. 