### PR TITLE
Remove General MIT License and Move License to Individual Packages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,5 @@
-MIT License
+# LICENSE
 
-Copyright (c) 2021 Adhithya Rajasekaran
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+This repository contains copyrighted material. All the copyright belongs to Adhithya Rajasekaran. Some material 
+is being provided under a license. So, please check the individual material to see if the material is licensed
+to be used and what license has been provided. 


### PR DESCRIPTION
I was recently advised that a general MIT license grant on the entire repo might not be a good idea. So, I am removing it and replacing it with MIT license grants on individual packages. 