### PR TITLE
Remove Non Standard Comments

### DIFF
--- a/learning/fortran/comments.md
+++ b/learning/fortran/comments.md
@@ -2,7 +2,7 @@
 
 Comments are how most programmers document code.
 
-To add a comment, you need to add one of the following characters in the first column - `c`, `C`, `*` or `!`.
+To add a comment, you need to add one of the following characters in the first column - `c`, `C`, or `*`.
 
 Here are some examples
 
@@ -26,20 +26,3 @@ program hello_world
     print *, "Hello World!!!"
 end program hello_world
 ```
-
-```fortran
-! This is a hello world program
-program hello_world
-    print *, "Hello World!!!"
-end program hello_world
-```
-
-If you use `!` in a statement, anything after `!` is considered a comment
-
-```fortran
-program hello_world
-    print *, "Hello World!!!" ! This is a hello world program
-end program hello_world
-```
-
-You can also use `d` or `D` in the first column to mark that line as a comment. But if you use the `-xld` option while compiling the code, they will be compiled as debug lines.


### PR DESCRIPTION
I found out that `!`, `d` and `D` are non-standard in Fortran. So, removing those. 