### PR TITLE
Enable Perl Build On Mac

### DIFF
--- a/.github/workflows/Mac-Build.yml
+++ b/.github/workflows/Mac-Build.yml
@@ -16,5 +16,7 @@ jobs:
       - run: npm install -g yarn
       - name: Install GCC along with GNU Fortran
         run: brew install gcc
+      - name: Install Perl if it doesn't exit
+        run: brew install perl
       - name: Running build
         run: ruby scripts/build.rb

--- a/programs/empty-program/perl/BUILD.darwin
+++ b/programs/empty-program/perl/BUILD.darwin
@@ -1,0 +1,1 @@
+perl empty_program.pl


### PR DESCRIPTION
Currently, Perl build is only running on Linux. I am now enabling it on Mac as well. Windows is a different story. 