### PR TITLE
Rename Empty Perl Program Name

### DIFF
--- a/programs/empty-program/perl/BUILD.darwin
+++ b/programs/empty-program/perl/BUILD.darwin
@@ -1,1 +1,1 @@
-perl empty_program.pl
+perl program.pl

--- a/programs/empty-program/perl/BUILD.linux
+++ b/programs/empty-program/perl/BUILD.linux
@@ -1,1 +1,1 @@
-perl empty_program.pl
+perl program.pl


### PR DESCRIPTION
I am trying to standardize the program names in repos. All the programs should be named `program`. Perl doesn't comply with this naming scheme yet. So, fixing that here. 