### PR TITLE
Enable Mac Build For Fortran

### DIFF
--- a/programs/empty-program/fortran/BUILD.darwin
+++ b/programs/empty-program/fortran/BUILD.darwin
@@ -1,0 +1,2 @@
+gfortran-11 program.f90 -o program
+./program


### PR DESCRIPTION
I was not able to enable fortran to build on Mac initially. This was because `gfortran` was not found. But after reading the Github Actions docs, I found out that I have to specify the correct version of the compiler as well. Doing that fixed my issue. So, enabling the Mac build. 