### PR TITLE
Simplify Linux Github Action

### DIFF
--- a/.github/workflows/Linux-Build.yml
+++ b/.github/workflows/Linux-Build.yml
@@ -14,11 +14,5 @@ jobs:
         uses: actions/checkout@v2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: npm install -g yarn
-      - name: Install GNU Fortran
-        run: sudo apt-get install gfortran
-      - name: Install OCaml
-        run: sudo apt-get install ocaml
-      - name: Install Haskell
-        run: sudo apt-get install haskell-platform
       - name: Running build
         run: ruby scripts/build.rb

--- a/.github/workflows/Linux-Build.yml
+++ b/.github/workflows/Linux-Build.yml
@@ -14,5 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: npm install -g yarn
+      - name: Install OCaml
+        run: sudo apt-get install ocaml
       - name: Running build
         run: ruby scripts/build.rb


### PR DESCRIPTION
Haskell and Fortran are already installed in the Linux runners provided by Github. We are installing them again and sometime it fails. To fix this, I am removing the steps that install Haskell and Fortran. 