### PR TITLE
Enable Build For D Language

### DIFF
--- a/programs/empty-program/WORKSPACE
+++ b/programs/empty-program/WORKSPACE
@@ -1,6 +1,7 @@
 ada
 c
 c++
+d
 csharp
 fortran
 go


### PR DESCRIPTION
I forgot to add `D` folder in the WORKSPACE file. This means that there was no build for D language. Fixing it in this PR. 