### PR TITLE
Enable Build For Erlang

### DIFF
--- a/programs/empty-program/WORKSPACE
+++ b/programs/empty-program/WORKSPACE
@@ -4,6 +4,7 @@ c++
 csharp
 d
 dart
+erlang
 fortran
 go
 haskell


### PR DESCRIPTION
I accidentally left out `Erlang` from the `WORKSPACE` file. Adding it back to enable the build. 