### PR TITLE
Add Mac Build Support For COBOL

### DIFF
--- a/programs/empty-program/cobol/BUILD.darwin
+++ b/programs/empty-program/cobol/BUILD.darwin
@@ -1,0 +1,2 @@
+cobc -x -free program.cob
+./program


### PR DESCRIPTION
I forgot to add support for Mac when I added COBOL to the mix. 