### PR TITLE
Move StopWatchy Package Code Shared Code

### DIFF
--- a/packages/ruby/shared-code/readme.md
+++ b/packages/ruby/shared-code/readme.md
@@ -1,0 +1,3 @@
+# Shared Code
+
+All the shared code that is shared between different packages stay here in this folder. Each folder inside this folder will correspond to a package that is published as a gem. If you want to consume the shared code, consume the code directly. Do not add them as a gem dependency as we want all packages to have no dependencies other than the standard library that Ruby comes with.

--- a/packages/ruby/shared-code/stopwatchy/stopwatch.rb
+++ b/packages/ruby/shared-code/stopwatchy/stopwatch.rb
@@ -1,0 +1,45 @@
+require_relative "stopwatchneverstartederror"
+require_relative "stopwatchneverstoppederror"
+
+class StopWatch
+    def initialize(monotonically_increasing_clock = true)
+        @start_time_stamp = nil
+        @stop_time_stamp = nil
+        @monotonically_increasing_clock = monotonically_increasing_clock
+    end
+
+    def start()
+        if @monotonically_increasing_clock
+            @start_time_stamp = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        else
+            @start_time_stamp = Time.now
+        end
+    end
+
+    def stop()
+        if @start_time_stamp.nil?
+            raise StopWatchNeverStartedError.new
+        end
+
+        if @monotonically_increasing_clock
+            @stop_time_stamp = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        else
+            @stop_time_stamp = Time.now
+        end
+    end
+
+    def get_elapsed_time()
+        if @start_time_stamp.nil?
+            raise StopWatchNeverStartedError.new
+        end
+
+        if @stop_time_stamp.nil?
+            raise StopWatchNeverStoppedError.new
+        end
+
+        elapsed_time = @stop_time_stamp - @start_time_stamp
+        @stop_time_stamp = nil
+        @start_time_stamp = nil
+        return elapsed_time
+    end
+end

--- a/packages/ruby/shared-code/stopwatchy/stopwatchneverstartederror.rb
+++ b/packages/ruby/shared-code/stopwatchy/stopwatchneverstartederror.rb
@@ -1,0 +1,3 @@
+class StopWatchNeverStartedError < StandardError
+
+end

--- a/packages/ruby/shared-code/stopwatchy/stopwatchneverstoppederror.rb
+++ b/packages/ruby/shared-code/stopwatchy/stopwatchneverstoppederror.rb
@@ -1,0 +1,3 @@
+class StopWatchNeverStoppedError < StandardError
+
+end

--- a/packages/ruby/stopwatchy/lib/stopwatchy.rb
+++ b/packages/ruby/stopwatchy/lib/stopwatchy.rb
@@ -1,55 +1,21 @@
 # frozen_string_literal: true
 
 require_relative "stopwatchy/version"
+require_relative "../../shared-code/stopwatchy/stopwatch"
+require_relative "../../shared-code/stopwatchy/stopwatchneverstartederror"
+require_relative "../../shared-code/stopwatchy/stopwatchneverstoppederror"
 
 module Stopwatchy
-  class StopWatchNeverStartedError < StandardError
-
-  end
-  class StopWatchNeverStoppedError < StandardError
-
-  end
-  class StopWatch
-    
-    def initialize(monotonically_increasing_clock = true)
-      @start_time_stamp = nil
-      @stop_time_stamp = nil
-      @monotonically_increasing_clock = monotonically_increasing_clock
-    end
-
-    def start()
-      if @monotonically_increasing_clock
-        @start_time_stamp = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      else
-        @start_time_stamp = Time.now
-      end
-    end
-
-    def stop()
-      if @start_time_stamp.nil?
-        raise StopWatchNeverStartedError.new
-      end
-
-      if @monotonically_increasing_clock
-        @stop_time_stamp = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      else
-        @stop_time_stamp = Time.now
-      end
-    end
-
-    def get_elapsed_time()
-      if @start_time_stamp.nil?
-        raise StopWatchNeverStartedError.new
-      end
-
-      if @stop_time_stamp.nil?
-        raise StopWatchNeverStoppedError.new
-      end
-
-      elapsed_time = @stop_time_stamp - @start_time_stamp
-      @stop_time_stamp = nil
-      @start_time_stamp = nil
-      return elapsed_time
+  def self.const_missing(missing_constant)
+    case missing_constant
+    when :StopWatch
+      Object.const_get(missing_constant)
+    when :StopWatchNeverStartedError
+      Object.const_get(missing_constant)
+    when :StopWatchNeverStoppedError
+      Object.const_get(missing_constant)
+    else
+      raise NoMethodError.new
     end
   end
 end


### PR DESCRIPTION
Similar to JS packages, we want to have almost all of the packages have no dependencies on anything other than the standard library that Ruby comes with. I will be doing this in several phases. The first phase is to move all the code out of packages to a shared code folder. This is the first PR in the first phase. 