### PR TITLE
Enable File Extension Information Package Build

### DIFF
--- a/packages/ruby/WORKSPACE
+++ b/packages/ruby/WORKSPACE
@@ -1,4 +1,4 @@
 loggy
 stopwatchy
-file-format-detector
+file-extension-information
 x86-simulator


### PR DESCRIPTION
The file-extension-information package is currently not building. So, enabling the build. There might things broken that need to be fixed up. 